### PR TITLE
force 'upb' for pychunkedgraph protobuf python implementation

### DIFF
--- a/kubetemplates/pychunkedgraph.yml
+++ b/kubetemplates/pychunkedgraph.yml
@@ -156,7 +156,7 @@ spec:
             - name: PCG_GRAPH_IDS
               value: ${PCG_GRAPH_IDS}
             - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
-              value: ${PCG_EDIT_PROTO_BACKEND}
+              value: "upb"
             - name: ZSTD_THREADS
               value: "4"
             - name: MESHING_URL_PREFIX


### PR DESCRIPTION
This mirrors other current yamls for meshing.  If flexibility via configuration settings is required, the global template (environment_examples/global_env_template.sh) should set:

export PCG_EDIT_PROTO_BACKEND=upb

Otherwise, there will be an error for just the pychunkedgraph service since `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION` will be set to an empty string.