### PR TITLE
Add tables to pmangement

### DIFF
--- a/kubetemplates/pmanagement.yml
+++ b/kubetemplates/pmanagement.yml
@@ -86,6 +86,10 @@ spec:
               value: "false"
             - name: DAF_CREDENTIALS
               value: /home/nginx/.cloudvolume/secrets/${CAVE_SECRET_FILENAME}
+            - name: PMANAGEMENT_PROOFREADING_TABLE
+              value: ${PMANAGEMENT_PROOFREADING_TABLE}
+            - name: PMANAGEMENT_NEURONINFORMATION_TABLE
+              value: ${PMANAGEMENT_NEURONINFORMATION_TABLE}
           resources:
             requests:
               memory: 1000Mi


### PR DESCRIPTION
Actually pass the values PMANAGEMENT_PROOFREADING_TABLE & PMANAGEMENT_NEURONINFORMATION_TABLE to the container.

These values are specified in both FANC & FlyWire config files.