### PR TITLE
feat: add job to run migration at startup of deployment

### DIFF
--- a/infrastructure/local/create_yaml_files_from_templates.sh
+++ b/infrastructure/local/create_yaml_files_from_templates.sh
@@ -9,7 +9,7 @@ envsubst < kubetemplates/ingress.yml > ${YAML_FOLDER}/ingress.yml
 envsubst < kubetemplates/ingress-service.yml > ${YAML_FOLDER}/ingress-service.yml
 envsubst < kubetemplates/materialize.yml > ${YAML_FOLDER}/materialize.yml
 envsubst < kubetemplates/materialize_worker.yml > ${YAML_FOLDER}/materialize_worker.yml
-envsubst < kubetemplates/materialize_migration.yml > ${YAML_FOLDER}/materialize_migration.yml
+envsubst < kubetemplates/materialize_migrations.yml > ${YAML_FOLDER}/materialize_migrations.yml
 envsubst < kubetemplates/pychunkedgraph.yml > ${YAML_FOLDER}/pychunkedgraph.yml
 envsubst < kubetemplates/meshing.yml > ${YAML_FOLDER}/meshing.yml
 envsubst < kubetemplates/nglstate.yml > ${YAML_FOLDER}/nglstate.yml

--- a/infrastructure/local/create_yaml_files_from_templates.sh
+++ b/infrastructure/local/create_yaml_files_from_templates.sh
@@ -9,7 +9,7 @@ envsubst < kubetemplates/ingress.yml > ${YAML_FOLDER}/ingress.yml
 envsubst < kubetemplates/ingress-service.yml > ${YAML_FOLDER}/ingress-service.yml
 envsubst < kubetemplates/materialize.yml > ${YAML_FOLDER}/materialize.yml
 envsubst < kubetemplates/materialize_worker.yml > ${YAML_FOLDER}/materialize_worker.yml
-envsubst < kubetemplates/materialize_migrate.yml > ${YAML_FOLDER}/materialize_migrate.yml
+envsubst < kubetemplates/materialize_migration.yml > ${YAML_FOLDER}/materialize_migration.yml
 envsubst < kubetemplates/pychunkedgraph.yml > ${YAML_FOLDER}/pychunkedgraph.yml
 envsubst < kubetemplates/meshing.yml > ${YAML_FOLDER}/meshing.yml
 envsubst < kubetemplates/nglstate.yml > ${YAML_FOLDER}/nglstate.yml

--- a/infrastructure/local/deploy_migration_job.sh
+++ b/infrastructure/local/deploy_migration_job.sh
@@ -6,15 +6,88 @@ ANNOTATION_COUNT=${ANNOTATIONENGINE_MAX_REPLICAS:-0}
 MATERIALIZATION_COUNT=${MAT_MAX_REPLICAS:-0}
 CELERY_WORKER_COUNT=${CELERY_PRODUCER_MIN_REPLICAS:-0}
 
+if (( $ANNOTATION_COUNT > 0 || $MATERIALIZATION_COUNT > 0 || $CELERY_WORKER_COUNT > 0 )); then
+    echo "Running database migration for materialize service"
+    
+    # Check if the job exists before attempting to delete it
+    if kubectl get job materialize-db-migration &> /dev/null; then
+        echo "Deleting existing migration job"
+        kubectl delete job materialize-db-migration
+    else
+        echo "No existing migration job found"
+    fi
 
-if (( $ANNOTATION_COUNT > 0 || $MATERIALIZATION_COUNT > 0 || $CELERY_WORKER_COUNT > 0 ));
-then
-  echo "Running database migration for materialize service"
-  envsubst < kubetemplates/materialize_migrations.yml > ${YAML_FOLDER}/materialize_migrations.yml
-  kubectl apply -f ${YAML_FOLDER}/materialize_migrations.yml
-  kubectl wait --for=condition=complete job/materialize-db-migration --timeout=600s
-  if [ $? -ne 0 ]; then
-    # echo "Migration job failed. Exiting deployment."
-    exit 1
-  fi
+    echo "Creating migration template"
+    envsubst < kubetemplates/materialize_migrations.yml > ${YAML_FOLDER}/materialize_migrations.yml
+    
+    echo "Applying migration job"
+    kubectl apply -f ${YAML_FOLDER}/materialize_migrations.yml
+
+    echo "Waiting for migration job to complete"
+
+    job_name="materialize-db-migration"
+    check_interval=5  # Check every 5 seconds
+    timeout=600  # Total timeout in seconds (10 minutes)
+    elapsed=0
+
+    while [ $elapsed -lt $timeout ]; do
+        # Check if the job exists
+        if ! kubectl get job $job_name &> /dev/null; then
+            echo "Migration job not found. It may have been deleted. Exiting deployment."
+            exit 1
+        fi
+
+        # Get the job status
+        job_status=$(kubectl get job $job_name -o jsonpath='{.status.conditions[*].type}')
+        
+        if [[ $job_status == *"Complete"* ]]; then
+            echo "Migration job completed. Checking exit code..."
+            pod_name=$(kubectl get pods --selector=job-name=$job_name --output=jsonpath='{.items[*].metadata.name}')
+            exit_code=$(kubectl get pod $pod_name -o jsonpath='{.status.containerStatuses[?(@.name=="cloudsql-proxy")].state.terminated.exitCode}')
+            
+            case $exit_code in
+                0)
+                    echo "Migration completed successfully."
+                    ;;
+                1)
+                    echo "Error: Migration failed."
+                    kubectl logs job/$job_name
+                    exit 1
+                    ;;
+                2)
+                    echo "Error: Cloud SQL Proxy did not become ready in time."
+                    kubectl logs job/$job_name
+                    exit 2
+                    ;;
+                3)
+                    echo "No auto-migrate command found. No migration was necessary."
+                    ;;
+                *)
+                    echo "Unknown exit code: $exit_code"
+                    kubectl logs job/$job_name
+                    exit $exit_code
+                    ;;
+            esac
+            break
+        elif [[ $job_status == *"Failed"* ]]; then
+            echo "Migration job failed. Checking logs:"
+            kubectl logs job/$job_name
+            exit 1
+        fi
+
+        echo "Job still running. Time elapsed: $elapsed seconds. Timeout: $timeout seconds."
+        sleep $check_interval
+        elapsed=$((elapsed + check_interval))
+    done
+
+    if [ $elapsed -ge $timeout ]; then
+        echo "Migration job timed out after $timeout seconds. Exiting deployment."
+        kubectl logs job/$job_name
+        exit 4  # Distinct exit code for timeout
+    fi
+
+    echo "Cleaning up the migration job"
+    kubectl delete job $job_name
+    echo "Migration process completed. Proceeding with deployment."
 fi
+echo "No services require database migration. Proceeding with deployment."

--- a/infrastructure/local/deploy_migration_job.sh
+++ b/infrastructure/local/deploy_migration_job.sh
@@ -1,0 +1,19 @@
+source env_config.sh
+source $ENV_REPO_PATH/$1.sh
+
+# Get replica counts for each service that communicates with the database
+ANNOTATION_COUNT=${ANNOTATIONENGINE_MAX_REPLICAS:-0}
+MATERIALIZATION_COUNT=${MAT_MAX_REPLICAS:-0}
+CELERY_WORKER_COUNT=${CELERY_PRODUCER_MIN_REPLICAS:-0}
+
+
+if (( $ANNOTATION_COUNT > 0 || $MATERIALIZATION_COUNT > 0 || $CELERY_WORKER_COUNT > 0 ));
+then
+  echo "Running database migration for materialize service"
+  kubectl apply -f ${YAML_FOLDER}/materialize_migration.yml
+  kubectl wait --for=condition=complete job/materialize-db-migration --timeout=600s
+  if [ $? -ne 0 ]; then
+    # echo "Migration job failed. Exiting deployment."
+    exit 1
+  fi
+fi

--- a/infrastructure/local/deploy_migration_job.sh
+++ b/infrastructure/local/deploy_migration_job.sh
@@ -10,6 +10,7 @@ CELERY_WORKER_COUNT=${CELERY_PRODUCER_MIN_REPLICAS:-0}
 if (( $ANNOTATION_COUNT > 0 || $MATERIALIZATION_COUNT > 0 || $CELERY_WORKER_COUNT > 0 ));
 then
   echo "Running database migration for materialize service"
+  envsubst < kubetemplates/materialize_migrations.yml > ${YAML_FOLDER}/materialize_migrations.yml
   kubectl apply -f ${YAML_FOLDER}/materialize_migrations.yml
   kubectl wait --for=condition=complete job/materialize-db-migration --timeout=600s
   if [ $? -ne 0 ]; then

--- a/infrastructure/local/deploy_migration_job.sh
+++ b/infrastructure/local/deploy_migration_job.sh
@@ -89,5 +89,6 @@ if (( $ANNOTATION_COUNT > 0 || $MATERIALIZATION_COUNT > 0 || $CELERY_WORKER_COUN
     echo "Cleaning up the migration job"
     kubectl delete job $job_name
     echo "Migration process completed. Proceeding with deployment."
+else 
+    echo "No services require database migration. Proceeding with deployment."
 fi
-echo "No services require database migration. Proceeding with deployment."

--- a/infrastructure/local/deploy_migration_job.sh
+++ b/infrastructure/local/deploy_migration_job.sh
@@ -10,7 +10,7 @@ CELERY_WORKER_COUNT=${CELERY_PRODUCER_MIN_REPLICAS:-0}
 if (( $ANNOTATION_COUNT > 0 || $MATERIALIZATION_COUNT > 0 || $CELERY_WORKER_COUNT > 0 ));
 then
   echo "Running database migration for materialize service"
-  kubectl apply -f ${YAML_FOLDER}/materialize_migration.yml
+  kubectl apply -f ${YAML_FOLDER}/materialize_migrations.yml
   kubectl wait --for=condition=complete job/materialize-db-migration --timeout=600s
   if [ $? -ne 0 ]; then
     # echo "Migration job failed. Exiting deployment."

--- a/infrastructure/local/update_services.sh
+++ b/infrastructure/local/update_services.sh
@@ -40,6 +40,8 @@ pprogress
 pmanagement
 cavecanary)
 
+./infrastructure/local/deploy_migration_job.sh $1
+
 for i in $(seq 0 1 $((${#MAX_REPLICA_ARRAY[@]}-1))); do
   echo $i
 

--- a/infrastructure/local/update_services_oneoff.sh
+++ b/infrastructure/local/update_services_oneoff.sh
@@ -3,6 +3,9 @@ source $ENV_REPO_PATH/$1.sh
 
 ./infrastructure/local/switch_context.sh $1
 
+./infrastructure/local/deploy_migration_job.sh $1
+
+
 mkdir -p ${YAML_FOLDER}
 envsubst < kubetemplates/$2.yml > ${YAML_FOLDER}/$2.yml
 kubectl apply -f ${YAML_FOLDER}/$2.yml

--- a/kubetemplates/materialize_migrations.yml
+++ b/kubetemplates/materialize_migrations.yml
@@ -13,10 +13,10 @@ spec:
       tolerations:
         - key: "pool"
           operator: "Equal"
-          value: "${LIGHTWEIGHT_POOL}"
+          value: "${STANDARD_POOL}"
           effect: "NoSchedule"
       nodeSelector:
-        cloud.google.com/gke-nodepool: ${LIGHTWEIGHT_POOL}
+        cloud.google.com/gke-nodepool: ${STANDARD_POOL}
       volumes:
         - name: materializationengine-config-volume
           configMap:

--- a/kubetemplates/materialize_migrations.yml
+++ b/kubetemplates/materialize_migrations.yml
@@ -48,7 +48,8 @@ spec:
               else
                   echo "auto-migrate command not found. Cannot apply auto migration."
                   echo "This could be due to the environment setup or the command not being implemented in this version of the image: v${MATERIALIZE_VERSION}."
-                  echo "Treating this as a success to allow the deployment to proceed."                                exit_code=3
+                  echo "Treating this as a success to allow the deployment to proceed."                                
+                  exit_code=3
               fi
 
               curl http://localhost:9091/quitquitquit # kill the cloudsql proxy sidecar

--- a/kubetemplates/materialize_migrations.yml
+++ b/kubetemplates/materialize_migrations.yml
@@ -3,47 +3,20 @@ kind: Job
 metadata:
   name: materialize-db-migration
 spec:
+  backoffLimit: 0
   template:
     metadata:
       name: materialize-db-migration
     spec:
       restartPolicy: Never
-      containers:
-        - name: sql-migration
-          image: ${DOCKER_REPOSITORY}/materializationengine:v${MATERIALIZE_VERSION}
-          command: ["/bin/sh", "-c"]
-          args:
-            - |
-              cat <<EOF > /app/run_migration.sh
-              #!/bin/sh
-              set -e
-              
-              # Attempt to import and run the migration function
-              python3 <<EOF2
-              try:
-                  from migration import migrate_static_schemas_in_aligned_volume_dbs
-                  migrate_static_schemas_in_aligned_volume_dbs()
-                  print("Migration completed successfully")
-              except ImportError:
-                  print("Migration function not found, skipping...")
-                  exit(0)
-              except Exception as e:
-                  print(f"Error during migration: {str(e)}")
-                  exit(1)
-              EOF2
-              EOF
-              
-              chmod +x /app/run_migration.sh
-              /app/run_migration.sh
-          env:
-            - name: MATERIALIZATION_ENGINE_SETTINGS
-              value: /app/materializationengine/instance/config.cfg
-          volumeMounts:
-            - name: cloudsql-instance-credentials-volume
-              mountPath: /secrets/cloudsql
-              readOnly: true
-            - name: materializationengine-config-volume
-              mountPath: /app/materializationengine/instance
+      shareProcessNamespace: true
+      tolerations:
+        - key: "pool"
+          operator: "Equal"
+          value: "${LIGHTWEIGHT_POOL}"
+          effect: "NoSchedule"
+      nodeSelector:
+        cloud.google.com/gke-nodepool: ${LIGHTWEIGHT_POOL}
       volumes:
         - name: materializationengine-config-volume
           configMap:
@@ -54,3 +27,96 @@ spec:
         - name: cloudsql-instance-credentials-volume
           secret:
             secretName: ${CLOUD_SQL_SERVICE_ACCOUNT_SECRET}
+      containers:
+        - name: migration
+          image: ${DOCKER_REPOSITORY}/materializationengine:v${MATERIALIZE_VERSION}
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -x
+                            
+              echo "Checking for auto-migrate command..."
+              if flask migrator auto-migrate --help >/dev/null 2>&1; then
+                echo "auto-migrate command found. Running migration..."
+                if flask migrator auto-migrate; then
+                  echo "Flask auto-migrate command executed successfully."
+                  exit_code=0
+                else
+                  echo "Error: Flask auto-migrate command failed."
+                  exit_code=1
+                fi
+              else
+                  echo "auto-migrate command not found. Cannot apply auto migration."
+                  echo "This could be due to the environment setup or the command not being implemented in this version of the image: v${MATERIALIZE_VERSION}."
+                  echo "Treating this as a success to allow the deployment to proceed."                                exit_code=3
+              fi
+
+              curl http://localhost:9091/quitquitquit # kill the cloudsql proxy sidecar
+
+              exit $exit_code
+          volumeMounts:
+            - name: google-cloud-key
+              mountPath: /home/nginx/.cloudvolume/secrets
+            - name: materializationengine-config-volume
+              mountPath: /app/materializationengine/instance/
+          env:
+            - name: MATERIALIZATION_ENGINE_SETTINGS
+              value: /app/materializationengine/instance/config.cfg
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /home/nginx/.cloudvolume/secrets/${GOOGLE_SECRET_FILENAME}
+            - name: LOCAL_SERVER_URL
+              value: "http://pychunkedgraph-read-service"
+            - name: AUTH_URI
+              value: ${AUTH_URI}
+            - name: LIMITER_CATEGORIES
+              value: '${MAT_LIMITER_CATEGORIES}'
+            - name: LIMITER_URI
+              value: ${LIMITER_URI}
+            - name: STICKY_AUTH_URL
+              value: ${STICKY_AUTH_URL}
+            - name: AUTH_URL
+              value: ${AUTH_URL}
+            - name: INFO_URL
+              value: ${INFO_URL}
+            - name: DAF_CREDENTIALS
+              value: /home/nginx/.cloudvolume/secrets/${CAVE_SECRET_FILENAME}
+            - name: FLASK_APP
+              value: /app/run.py
+            - name: PYTHONPATH
+              value: /app
+            - name: FLASK_DEBUG
+              value: "1"
+        - name: cloudsql-proxy
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.13.0
+          command:
+            - "/cloud-sql-proxy"
+          args:
+            - "--admin-port=9091"
+            - "--quitquitquit"
+            - "--exit-zero-on-sigterm"
+            - "--address=0.0.0.0"
+            - "--port=3306"
+            - "--health-check"
+            - "--credentials-file=/secrets/cloudsql/${GOOGLE_SECRET_FILENAME}"
+            - "${PROJECT_NAME}:${REGION}:${SQL_INSTANCE_NAME}"
+          volumeMounts:
+            - name: cloudsql-instance-credentials-volume
+              mountPath: /secrets/cloudsql
+              readOnly: true
+          ports:
+              - containerPort: 3306  # The port your database listens on
+              - containerPort: 9091  # Admin port for shutdown requests
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532  # non-root user
+          readinessProbe:
+            tcpSocket:
+              port: 3306
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9091
+            initialDelaySeconds: 60
+            periodSeconds: 10

--- a/kubetemplates/materialize_migrations.yml
+++ b/kubetemplates/materialize_migrations.yml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: materialize-db-migration
+spec:
+  template:
+    metadata:
+      name: materialize-db-migration
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: sql_migration
+        image: ${DOCKER_REPOSITORY}/materializationengine:v${MATERIALIZE_VERSION}
+        command: ["/bin/sh", "-c"]
+        args: 
+            - |
+              cat <<EOF > /app/run_migration.sh
+              #!/bin/sh
+              set -e
+              
+              # Attempt to import and run the migration function
+              python3 <<EOF2
+              try:
+                  from migration import migrate_static_schemas_in_aligned_volume_dbs
+                  migrate_static_schemas_in_aligned_volume_dbs()
+                  print("Migration completed successfully")
+              except ImportError:
+                  print("Migration function not found, skipping...")
+                  exit(0)
+              except Exception as e:
+                  print(f"Error during migration: {str(e)}")
+                  exit(1)
+              EOF2
+              
+              EOF
+              
+              chmod +x /app/run_migration.sh
+              /app/run_migration.sh
+        env:
+        - name: MATERIALIZATION_ENGINE_SETTINGS
+          value: /app/materializationengine/instance/config.cfg
+      volumeMounts:
+        - name: cloudsql-instance-credentials-volume
+          mountPath: /secrets/cloudsql
+          readOnly: true
+      volumes:
+        - name: materializationengine-config-volume
+          configMap:
+            name: materializationengine-config-v${MATERIALIZE_CONFIG_VERSION}
+        - name: google-cloud-key
+          secret:
+            secretName: ${PYCG_SERVICE_ACCOUNT_SECRET}
+        - name: cloudsql-instance-credentials-volume
+          secret:
+            secretName: ${CLOUD_SQL_SERVICE_ACCOUNT_SECRET}

--- a/kubetemplates/materialize_migrations.yml
+++ b/kubetemplates/materialize_migrations.yml
@@ -9,10 +9,10 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-      - name: sql_migration
-        image: ${DOCKER_REPOSITORY}/materializationengine:v${MATERIALIZE_VERSION}
-        command: ["/bin/sh", "-c"]
-        args: 
+        - name: sql-migration
+          image: ${DOCKER_REPOSITORY}/materializationengine:v${MATERIALIZE_VERSION}
+          command: ["/bin/sh", "-c"]
+          args:
             - |
               cat <<EOF > /app/run_migration.sh
               #!/bin/sh
@@ -31,18 +31,19 @@ spec:
                   print(f"Error during migration: {str(e)}")
                   exit(1)
               EOF2
-              
               EOF
               
               chmod +x /app/run_migration.sh
               /app/run_migration.sh
-        env:
-        - name: MATERIALIZATION_ENGINE_SETTINGS
-          value: /app/materializationengine/instance/config.cfg
-      volumeMounts:
-        - name: cloudsql-instance-credentials-volume
-          mountPath: /secrets/cloudsql
-          readOnly: true
+          env:
+            - name: MATERIALIZATION_ENGINE_SETTINGS
+              value: /app/materializationengine/instance/config.cfg
+          volumeMounts:
+            - name: cloudsql-instance-credentials-volume
+              mountPath: /secrets/cloudsql
+              readOnly: true
+            - name: materializationengine-config-volume
+              mountPath: /app/materializationengine/instance
       volumes:
         - name: materializationengine-config-volume
           configMap:


### PR DESCRIPTION
Creates a Kuberenetes job that attempts to run a migration script to update all "static" models in any aligned volumed database that is set in the pod's ConfigMap.

The job will dynamically create a bash script to run the migration code. If the code is not present it will fail gracefully allowing pods to be deployed. If the script runs with a failure it should block the deployment of pods (of that version, so a rollback is needed until fixed). 