### PR TITLE
Fix possible typo in Aug 2024 update

### DIFF
--- a/infrastructure/local/create_service_accounts.sh
+++ b/infrastructure/local/create_service_accounts.sh
@@ -15,7 +15,7 @@ gcloud projects add-iam-policy-binding $PROJECT_NAME --member serviceAccount:$PY
 gcloud projects add-iam-policy-binding $PROJECT_NAME --member serviceAccount:$PYCG_SERVICE_ACCOUNT_NAME@$PROJECT_NAME.iam.gserviceaccount.com --role roles/pubsub.editor
 gcloud projects add-iam-policy-binding $PROJECT_NAME --member serviceAccount:$PYCG_SERVICE_ACCOUNT_NAME@$PROJECT_NAME.iam.gserviceaccount.com --role roles/storage.objectViewer
 gcloud projects add-iam-policy-binding $PROJECT_NAME --member serviceAccount:$PYCG_SERVICE_ACCOUNT_NAME@$PROJECT_NAME.iam.gserviceaccount.com --role roles/cloudsql.admin
-gcloud projects add-iam-policy-binding <PROJECT_ID>  --member serviceAccount:$PYCG_SERVICE_ACCOUNT_NAME@$PROJECT_NAME.iam.gserviceaccount.com --role roles/storage.objectAdmin
+gcloud projects add-iam-policy-binding $PROJECT_NAME  --member serviceAccount:$PYCG_SERVICE_ACCOUNT_NAME@$PROJECT_NAME.iam.gserviceaccount.com --role roles/storage.objectAdmin
 
 
 gcloud iam service-accounts create $SKELETON_SERVICE_ACCOUNT_NAME --display-name=SkeletonService-$ENVIRONMENT


### PR DESCRIPTION
Noticed an error running infrastructure/local/create_service_accounts.sh, and the line seems to be a typo where `<PROJECT ID>` was used instead of `$PROJECT_NAME`.